### PR TITLE
Preview on v0.16.34

### DIFF
--- a/config.ts
+++ b/config.ts
@@ -16,7 +16,7 @@ config.translations.translated_strings_path = "./app_data/translations_source/tr
 
 config.git = {
   content_repo: "https://github.com/IDEMSInternational/plh-teens-app-tz-content.git",
-  content_tag_latest: "1.1.24",
+  content_tag_latest: "1.1.25",
 };
 
 config.android = {


### PR DESCRIPTION
PR to generate web preview on code version v0.16.34. Content sync on this branch shows no changes. 
![image](https://github.com/user-attachments/assets/859c0206-534f-4e6e-bdca-66c23e8b7876)

Like for #41, when running locally on this code branch I only see a blank screen. 
![image](https://github.com/user-attachments/assets/ac85f247-4470-4237-968d-1a99f0dac027)
